### PR TITLE
fix: update or delete broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ sessions.
 ## Resources
 
 ### Katas
-* Code Katas: http://codekata.pragprog.com/
-* RNC Description: http://codingdojo.org/cgi-bin/wiki.pl?KataRomanCalculator
+* RNC Description: https://codingdojo.org/kata/RomanCalculator/
 
 ### Roman Numeral Live Performances
 * Enrique Comba Riepenhausen: http://katas.softwarecraftsmanship.org/?p=21


### PR DESCRIPTION
Both Katas links are broken in the readme:
> Code Katas: http://codekata.pragprog.com/
> RNC Description: http://codingdojo.org/cgi-bin/wiki.pl?KataRomanCalculator

This PR deletes the former and updates the latter.